### PR TITLE
Fix Outdated Links

### DIFF
--- a/pages/commands/import.mdx
+++ b/pages/commands/import.mdx
@@ -26,7 +26,7 @@ This command allows you to import XP data from another bot.
 -   Polaris
 -   A CSV File
 
-If the bot you're wanting to import from isn't shown here, join our [support server](https://go.kiai.wtf/support) and let us know!
+If the bot you're wanting to import from isn't shown here, join our [support server](https://go.buape.com/discord) and let us know!
 
 <Callout emoji="⚠️">
 	You must use the [/factory-reset](/commands/factory-reset) command before

--- a/pages/commands/leaderboard.mdx
+++ b/pages/commands/leaderboard.mdx
@@ -12,4 +12,4 @@ This command is available to everyone.
 
 ## Description
 
-The `/leaderboard` command will show the top 10 members with the most XP in the server, and provide a link to the full leaderboard located at https://kiai.wtf.
+The `/leaderboard` command will display a leaderboard showing the top 10 members with the most XP in the server, with buttons to switch between pages.

--- a/pages/features/api.mdx
+++ b/pages/features/api.mdx
@@ -8,7 +8,7 @@ If you would like an API key, join our support server and ask a developer there.
 
 The full list of endpoints can be found here:
 
-https://api.kiaibot.com/docs
+https://api.kiai.app/docs
 
 ## Authentication
 


### PR DESCRIPTION
When going over the docs I saw a few invalid/outdated links so I went ahead and replaced them with their working counterparts. I also updated the leaderboard description.